### PR TITLE
shmem/mem: do not return in void shmem_free()

### DIFF
--- a/src/shmem/mem.c
+++ b/src/shmem/mem.c
@@ -14,7 +14,7 @@ void *shmem_malloc(size_t size)
 
 void shmem_free(void *ptr)
 {
-    return OSHMPI_free(ptr);
+    OSHMPI_free(ptr);
 }
 
 void *shmem_realloc(void *ptr, size_t size)


### PR DESCRIPTION
`shmem_free` and `OSHMPI_free` are both `void`, but returning void to `shmem_free` produces warning for some compiler. 