### PR TITLE
config: skip opa target if unneeded

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -22,7 +22,10 @@ liboshmpi_la_LDFLAGS = $(external_ldflags)
 liboshmpi_la_LIBADD = $(convenience_libs)
 EXTRA_liboshmpi_la_DEPENDENCIES = $(convenience_libs)
 EXTRA_DIST = 
-dist_noinst_SCRIPTS = autogen.sh @opasrcdir@/autogen.sh
+dist_noinst_SCRIPTS = autogen.sh
+if OSHMPI_HAVE_OPA
+dist_noinst_SCRIPTS += @opasrcdir@/autogen.sh
+endif
 
 include src/Makefile.mk
 include env/Makefile.mk

--- a/configure.ac
+++ b/configure.ac
@@ -376,6 +376,8 @@ if test "$enable_threads" == "multiple"; then
     fi 
 fi
 
+AM_CONDITIONAL([OSHMPI_HAVE_OPA], [test "$enable_threads" == "multiple" ])
+
 # Thread package used in critical section and asynchronous thread
 AC_ARG_WITH([thread-package],
 [  --with-thread-package=posix|pthread


### PR DESCRIPTION
This patch fixes the error when compiling with `--enable-threads=single`.