### PR TITLE
oshmpi_impl: fix comparison of negative required_ext_nelems

### DIFF
--- a/src/include/oshmpi_impl.h
+++ b/src/include/oshmpi_impl.h
@@ -419,7 +419,7 @@ OSHMPI_STATIC_INLINE_PREFIX void OSHMPI_translate_disp_to_vaddr(OSHMPI_symm_obj_
  * The caller must check the returned datatype to free it when necessary. */
 OSHMPI_STATIC_INLINE_PREFIX void OSHMPI_create_strided_dtype(size_t nelems, ptrdiff_t stride,
                                                              MPI_Datatype mpi_type,
-                                                             size_t required_ext_nelems,
+                                                             int required_ext_nelems,
                                                              size_t * strided_cnt,
                                                              MPI_Datatype * strided_type)
 {


### PR DESCRIPTION
We pass -1 for the `required_ext_nelems` to `OSHMPI_create_strided_dtype` in order to skip the MPI type creation when resizing is not needed. But checking if the unsigned type `required_ext_nelems` > 0 will always result in true (except for 0 of course). We may just make the parameter a signed type.