### PR TITLE
strided: set zero to disable type resize at strided RMA

### DIFF
--- a/src/internal/rma_impl.h
+++ b/src/internal/rma_impl.h
@@ -93,13 +93,13 @@ OSHMPI_STATIC_INLINE_PREFIX void OSHMPI_ctx_iput(shmem_ctx_t ctx OSHMPI_ATTRIBUT
     if (nelems == 0)
         return;
 
-    OSHMPI_create_strided_dtype(nelems, origin_st, mpi_type, -1 /* no required extent */ ,
+    OSHMPI_create_strided_dtype(nelems, origin_st, mpi_type, 0 /* no required extent */ ,
                                 &origin_count, &origin_type);
     if (origin_st == target_st) {
         target_type = origin_type;
         target_count = origin_count;
     } else
-        OSHMPI_create_strided_dtype(nelems, target_st, mpi_type, -1 /* no required extent */ ,
+        OSHMPI_create_strided_dtype(nelems, target_st, mpi_type, 0 /* no required extent */ ,
                                     &target_count, &target_type);
 
     ctx_put_nbi_impl(ctx, origin_type, target_type, origin_addr, target_addr,
@@ -151,13 +151,13 @@ OSHMPI_STATIC_INLINE_PREFIX void OSHMPI_ctx_iget(shmem_ctx_t ctx OSHMPI_ATTRIBUT
     if (nelems == 0)
         return;
 
-    OSHMPI_create_strided_dtype(nelems, origin_st, mpi_type, -1 /* no required extent */ ,
+    OSHMPI_create_strided_dtype(nelems, origin_st, mpi_type, 0 /* no required extent */ ,
                                 &origin_count, &origin_type);
     if (origin_st == target_st) {
         target_type = origin_type;
         target_count = origin_count;
     } else
-        OSHMPI_create_strided_dtype(nelems, target_st, mpi_type, -1 /* no required extent */ ,
+        OSHMPI_create_strided_dtype(nelems, target_st, mpi_type, 0 /* no required extent */ ,
                                     &target_count, &target_type);
 
     ctx_get_nbi_impl(ctx, origin_type, target_type, origin_addr, target_addr,


### PR DESCRIPTION
Previous code used -1 to disable type resize when creating datatypes for
strided RMA. However, the parameter is size_t type and can never be
negative. Thus, we should use zero instead of -1 for such purpose.