### PR TITLE
Use MPIX_RMA_abs routines to avoid dest disp translation

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -612,6 +612,26 @@ if test "$enable_cuda" = "yes" ; then
 fi
 AM_CONDITIONAL([OSHMPI_ENABLE_CUDA], [test "$enable_cuda" == "yes" ])
 
+## Check for enabling MPIX_RMA_abs
+AC_ARG_ENABLE(mpix-rma-abs,
+[  --enable-mpix-rma-abs=[option]
+                         Use MPI extension routines MPIX_RMA_abs for all operations.
+                         Supported options include:
+                           auto - enable if the abs extensions are detected in the MPI library,
+                                  otherwise use default MPI RMA routines
+                           no -  disable (default)],
+                         [ enable_mpix_rma_abs=$enableval ],
+                         [ enable_mpix_rma_abs=no ])
+AC_MSG_CHECKING(MPIX_RMA_abs)
+AC_MSG_RESULT($enable_mpix_rma_abs)
+if test "$enable_mpix_rma_abs" == "auto" ; then
+    AC_CHECK_FUNCS([MPIX_Put_abs MPIX_Get_abs],
+                   [have_mpix_rma_abs=yes], [[have_mpix_rma_abs=no]])
+    if test "$have_mpix_rma_abs" == "yes" ; then
+        AC_DEFINE_UNQUOTED(OSHMPI_USE_MPIX_RMA_ABS,1,[Use MPIX_RMA_abs for all operations ])
+    fi
+fi
+
 # Define corresponding MPI datatypes
 # size_t is a unsigned integer type
 AC_CHECK_SIZEOF(size_t)

--- a/src/internal/rma_impl.h
+++ b/src/internal/rma_impl.h
@@ -25,9 +25,16 @@ OSHMPI_STATIC_INLINE_PREFIX void ctx_put_nbi_impl(OSHMPI_ictx_t * ictx,
                                     OSHMPI_ICTX_DISP_MODE(ictx), &target_disp);
     OSHMPI_ASSERT(target_disp >= 0);
 
+
+#ifdef OSHMPI_USE_MPIX_RMA_ABS
+    OSHMPI_FORCEINLINE()
+        OSHMPI_CALLMPI(MPIX_Put_abs(origin_addr, (int) origin_count, origin_type, pe,
+                                    target_disp, (int) target_count, target_type, ictx->win));
+#else
     OSHMPI_FORCEINLINE()
         OSHMPI_CALLMPI(MPI_Put(origin_addr, (int) origin_count, origin_type, pe,
                                target_disp, (int) target_count, target_type, ictx->win));
+#endif
     OSHMPI_SET_OUTSTANDING_OP(ictx, OSHMPI_OP_OUTSTANDING);     /* PUT is always outstanding */
 }
 
@@ -46,9 +53,15 @@ OSHMPI_STATIC_INLINE_PREFIX void ctx_get_nbi_impl(OSHMPI_ictx_t * ictx,
                                     OSHMPI_ICTX_DISP_MODE(ictx), &target_disp);
     OSHMPI_ASSERT(target_disp >= 0);
 
+#ifdef OSHMPI_USE_MPIX_RMA_ABS
+    OSHMPI_FORCEINLINE()
+        OSHMPI_CALLMPI(MPIX_Get_abs(origin_addr, (int) origin_count, origin_type, pe,
+                                    target_disp, (int) target_count, target_type, ictx->win));
+#else
     OSHMPI_FORCEINLINE()
         OSHMPI_CALLMPI(MPI_Get(origin_addr, (int) origin_count, origin_type, pe,
                                target_disp, (int) target_count, target_type, ictx->win));
+#endif
     OSHMPI_SET_OUTSTANDING_OP(ictx, completion);        /* GET can be outstanding or completed */
 }
 

--- a/src/internal/setup_impl.c
+++ b/src/internal/setup_impl.c
@@ -99,6 +99,9 @@ void OSHMPI_set_mpi_info_args(MPI_Info info)
     OSHMPI_CALLMPI(MPI_Info_set(info, "which_rma_ops", "put,get"));
     OSHMPI_CALLMPI(MPI_Info_set(info, "rma_op_types:put", "contig:unlimited,vector:unlimited"));
     OSHMPI_CALLMPI(MPI_Info_set(info, "rma_op_types:get", "contig:unlimited,vector:unlimited"));
+#ifdef OSHMPI_USE_MPIX_RMA_ABS
+    OSHMPI_CALLMPI(MPI_Info_set(info, "rma_abs", "true"));
+#endif
 }
 
 #ifdef OSHMPI_ENABLE_DYNAMIC_WIN
@@ -547,6 +550,12 @@ static void print_env(void)
 #endif
                       "    --enable-cuda         "
 #ifdef OSHMPI_ENABLE_CUDA
+                      "yes\n"
+#else
+                      "no\n"
+#endif
+                      "    --enable-mpix-rma-abs         "
+#ifdef OSHMPI_USE_MPIX_RMA_ABS
                       "yes\n"
 #else
                       "no\n"


### PR DESCRIPTION
Remaining work for this PR:
- [ ] Implement abs version for other AMO/RMA routines
- [ ] If the base address of heap and global data on all processes is not symmetric, directly using local dest in put/get is wrong! We should enable it only when it is symmetric, or store base offsets as fallback. In current code, it simply assumes it is symmetric.

Note: a later commit for dynamic window will largely refactor the code. The above bug will also be addressed. Do not merge before that commit!