### PR TITLE
rma: use atomic flag for op tracking

### DIFF
--- a/src/include/oshmpi_impl.h
+++ b/src/include/oshmpi_impl.h
@@ -129,7 +129,7 @@ typedef enum {
 
 typedef struct OSHMPI_ictx {
     MPI_Win win;
-    unsigned int outstanding_op;
+    OSHMPIU_atomic_flag_t outstanding_op;
 #if defined(OSHMPI_ENABLE_DYNAMIC_WIN)
     OSHMPI_disp_mode_t disp_mode;
 #endif
@@ -759,7 +759,7 @@ enum {
 #ifdef OSHMPI_ENABLE_OP_TRACKING
 #define OSHMPI_SET_OUTSTANDING_OP(ctx, completion) do {       \
         if (completion == OSHMPI_OP_COMPLETED) break;         \
-        ctx->outstanding_op = 1;                              \
+        OSHMPIU_ATOMIC_FLAG_STORE(ctx->outstanding_op, 1);    \
         } while (0)
 #else
 #define OSHMPI_SET_OUTSTANDING_OP(ctx, completion) do {} while (0)

--- a/src/internal/am_impl.c
+++ b/src/internal/am_impl.c
@@ -82,11 +82,6 @@ static void *am_cb_async_progress(void *arg OSHMPI_ATTRIBUTE((unused)))
 
     return NULL;
 }
-#else
-static void *am_cb_async_progress(void *arg OSHMPI_ATTRIBUTE((unused)))
-{
-    return NULL;
-}
 #endif /* end of !defined(OSHMPI_DISABLE_AM_ASYNC_THREAD) */
 
 #define OSHMPI_AM_CB_PROGRESS_POLL_NCNT 1

--- a/src/internal/order_impl.h
+++ b/src/internal/order_impl.h
@@ -9,13 +9,13 @@
 #include "oshmpi_impl.h"
 
 #ifdef OSHMPI_ENABLE_OP_TRACKING
-#define CHECK_FLAG(flag) (flag)
+#define CHECK_FLAG(flag) OSHMPIU_ATOMIC_FLAG_LOAD(flag)
 #else
 #define CHECK_FLAG(flag) (1)
 #endif
 
 #ifdef OSHMPI_ENABLE_OP_TRACKING
-#define RESET_FLAG(flag) do {flag = 0;} while (0)
+#define RESET_FLAG(flag) do {OSHMPIU_ATOMIC_FLAG_STORE(flag, 0);} while (0)
 #else
 #define RESET_FLAG(flag) do {} while (0)
 #endif

--- a/src/internal/setup_impl.c
+++ b/src/internal/setup_impl.c
@@ -106,8 +106,8 @@ static void initialize_symm_win()
 {
     MPI_Info info = MPI_INFO_NULL;
     OSHMPI_global.symm_ictx.win = MPI_WIN_NULL;
-    OSHMPI_global.symm_ictx.outstanding_op = 0;
     OSHMPI_global.symm_ictx.disp_mode = OSHMPI_ABS_DISP;
+    OSHMPIU_ATOMIC_FLAG_STORE(OSHMPI_global.symm_ictx.outstanding_op, 0);
 
     OSHMPI_CALLMPI(MPI_Info_create(&info));
 
@@ -195,7 +195,7 @@ static void initialize_symm_text(void)
 {
     MPI_Info info = MPI_INFO_NULL;
     OSHMPI_global.symm_data_ictx.win = MPI_WIN_NULL;
-    OSHMPI_global.symm_data_ictx.outstanding_op = 0;
+    OSHMPIU_ATOMIC_FLAG_STORE(OSHMPI_global.symm_data_ictx.outstanding_op, 0);
 
     void *base = OSHMPI_DATA_START;
     MPI_Aint size = (MPI_Aint) OSHMPI_DATA_SIZE;
@@ -233,7 +233,7 @@ static void initialize_symm_heap(void)
 
     OSHMPI_global.symm_heap_mspace = NULL;
     OSHMPI_global.symm_heap_ictx.win = MPI_WIN_NULL;
-    OSHMPI_global.symm_heap_ictx.outstanding_op = 0;
+    OSHMPIU_ATOMIC_FLAG_STORE(OSHMPI_global.symm_heap_ictx.outstanding_op, 0);
 
     /* Ensure extra bookkeeping space in MSPACE */
     size = OSHMPI_ALIGN(OSHMPI_env.symm_heap_size, OSHMPI_global.page_sz);

--- a/src/internal/space_impl.c
+++ b/src/internal/space_impl.c
@@ -16,7 +16,7 @@ static void space_ictx_create(void *base, MPI_Aint size, MPI_Info info, OSHMPI_i
     OSHMPI_CALLMPI(MPI_Win_create(base, size, 1 /* disp_unit */ , info,
                                   OSHMPI_global.comm_world, &ictx->win));
     OSHMPI_CALLMPI(MPI_Win_lock_all(MPI_MODE_NOCHECK, ictx->win));
-    ictx->outstanding_op = 0;
+    OSHMPIU_ATOMIC_FLAG_STORE(ictx->outstanding_op, 0);
     OSHMPI_ICTX_SET_DISP_MODE(ictx, OSHMPI_RELATIVE_DISP);
 }
 
@@ -118,7 +118,7 @@ void OSHMPI_space_create(shmemx_space_config_t space_config, OSHMPI_space_t ** s
     space->config = space_config;
 #ifndef OSHMPI_ENABLE_DYNAMIC_WIN
     space->default_ictx.win = MPI_WIN_NULL;
-    space->default_ictx.outstanding_op = 0;
+    OSHMPIU_ATOMIC_FLAG_STORE(space->default_ictx.outstanding_op, 0);
 #endif
 
     OSHMPI_DBGMSG


### PR DESCRIPTION
When multithreading safety is enabled, multiple threads may update the
op tracking flag concurrently. Thus, we have to use atomic int type.