### PR TITLE
Revert "inline: setup pragma to inline only perf-critical path"

### DIFF
--- a/src/include/oshmpi_impl.h
+++ b/src/include/oshmpi_impl.h
@@ -492,7 +492,6 @@ OSHMPI_STATIC_INLINE_PREFIX void ctx_local_complete_impl(shmem_ctx_t ctx
                                                          OSHMPI_ATTRIBUTE((unused)), int pe,
                                                          MPI_Win win)
 {
-#pragma forceinline
     OSHMPI_CALLMPI(MPI_Win_flush_local(pe, win));
 }
 

--- a/src/internal/rma_impl.h
+++ b/src/internal/rma_impl.h
@@ -23,7 +23,6 @@ OSHMPI_STATIC_INLINE_PREFIX void ctx_put_nbi_impl(shmem_ctx_t ctx OSHMPI_ATTRIBU
 
     /* TODO: check non-int inputs exceeds int limit */
 
-#pragma forceinline
     OSHMPI_CALLMPI(MPI_Put(origin_addr, (int) origin_count, origin_type, pe,
                            target_disp, (int) target_count, target_type, win));
     OSHMPI_SET_OUTSTANDING_OP(win, OSHMPI_OP_OUTSTANDING);      /* PUT is always outstanding */
@@ -48,7 +47,6 @@ OSHMPI_STATIC_INLINE_PREFIX void ctx_get_nbi_impl(shmem_ctx_t ctx OSHMPI_ATTRIBU
 
     /* TODO: check non-int inputs exceeds int limit */
 
-#pragma forceinline
     OSHMPI_CALLMPI(MPI_Get(origin_addr, (int) origin_count, origin_type, pe,
                            target_disp, (int) target_count, target_type, win));
     OSHMPI_SET_OUTSTANDING_OP(win, completion); /* GET can be outstanding or completed */

--- a/src/shmem/mem.c
+++ b/src/shmem/mem.c
@@ -9,25 +9,21 @@
 
 void *shmem_malloc(size_t size)
 {
-#pragma noinline recursive
     return OSHMPI_malloc(size);
 }
 
 void shmem_free(void *ptr)
 {
-#pragma noinline recursive
     OSHMPI_free(ptr);
 }
 
 void *shmem_realloc(void *ptr, size_t size)
 {
-#pragma noinline recursive
     return OSHMPI_realloc(ptr, size);
 }
 
 void *shmem_align(size_t alignment, size_t size)
 {
-#pragma noinline recursive
     return OSHMPI_align(alignment, size);
 }
 
@@ -35,7 +31,6 @@ void *shmem_calloc(size_t count, size_t size)
 {
     void *ptr = NULL;
 
-#pragma noinline recursive
     ptr = OSHMPI_malloc(size);
     memset(ptr, 0, count * size);
 

--- a/src/shmem/setup.c
+++ b/src/shmem/setup.c
@@ -9,7 +9,6 @@
 
 void shmem_init(void)
 {
-#pragma noinline recursive
     OSHMPI_initialize_thread(OSHMPI_DEFAULT_THREAD_SAFETY, NULL);
     if (OSHMPI_env.version && OSHMPI_global.world_rank == 0)
         OSHMPI_PRINTF("SHMEM library version:\n"
@@ -31,7 +30,6 @@ int shmem_n_pes(void)
 
 void shmem_finalize(void)
 {
-#pragma noinline recursive
     OSHMPI_finalize();
 }
 
@@ -43,7 +41,6 @@ void shmem_global_exit(int status)
 int shmem_init_thread(int requested, int *provided)
 {
     int mpi_errno = MPI_SUCCESS;
-#pragma noinline recursive
     mpi_errno = OSHMPI_initialize_thread(requested, provided);
 
     if (OSHMPI_env.version && OSHMPI_global.world_rank == 0)


### PR DESCRIPTION
This reverts commit 5347f86f8bc4ba4529ba5d00706286505a4510d3.