### PR TITLE
config: fix --enable-fast=ndebug macro

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -612,6 +612,9 @@ if test "$enable_cuda" = "yes" ; then
 fi
 AM_CONDITIONAL([OSHMPI_ENABLE_CUDA], [test "$enable_cuda" == "yes" ])
 
+# check for attribute support
+PAC_C_GNU_ATTRIBUTE
+
 # Define corresponding MPI datatypes
 # size_t is a unsigned integer type
 AC_CHECK_SIZEOF(size_t)

--- a/src/include/oshmpi_impl.h
+++ b/src/include/oshmpi_impl.h
@@ -63,13 +63,13 @@ typedef enum {
 #define OSHMPI_ENABLE_DIRECT_AMO_RUNTIME 0
 #else /* default make decision at runtime */
 
-#ifdef OSHMPI_ENABLE_FAST
+#ifdef OSHMPI_DISABLE_DEBUG
 #define OSHMPI_ENABLE_DIRECT_AMO_RUNTIME (OSHMPI_global.amo_direct)
 #else /* runtime with debug */
 #define OSHMPI_ENABLE_DIRECT_AMO_RUNTIME (OSHMPI_env.amo_dbg_mode == OSHMPI_DBG_DIRECT ||   \
                                             (OSHMPI_env.amo_dbg_mode == OSHMPI_DBG_AUTO &&  \
                                                     OSHMPI_global.amo_direct))
-#endif /* end of OSHMPI_ENABLE_FAST */
+#endif /* end of OSHMPI_DISABLE_DEBUG */
 #endif /* end of OSHMPI_ENABLE_DIRECT_AMO */
 
 typedef enum {
@@ -90,7 +90,7 @@ OSHMPI_STATIC_INLINE_PREFIX int OSHMPI_check_gpu_direct_rma(const void *origin_a
 #else /* default make decision at runtime */
 #define OSHMPI_ENABLE_DIRECT_RMA_CONFIG 0
 
-#ifdef OSHMPI_ENABLE_FAST
+#ifdef OSHMPI_DISABLE_DEBUG
 #define OSHMPI_ENABLE_DIRECT_RMA_RUNTIME(origin_addr, sobj_memkind, rma) \
             OSHMPI_check_gpu_direct_rma(origin_addr, sobj_memkind, rma)
 #else /* runtime with debug */
@@ -99,7 +99,7 @@ OSHMPI_STATIC_INLINE_PREFIX int OSHMPI_check_gpu_direct_rma(const void *origin_a
                 (OSHMPI_env.rma_dbg_mode == OSHMPI_DBG_AUTO &&           \
                         OSHMPI_check_gpu_direct_rma(origin_addr, sobj_memkind, rma)))
 
-#endif /* end of OSHMPI_ENABLE_FAST */
+#endif /* end of OSHMPI_DISABLE_DEBUG */
 #endif /* end of OSHMPI_ENABLE_AM_RMA */
 
 #if defined(OSHMPI_ENABLE_AM_ASYNC_THREAD)
@@ -264,7 +264,7 @@ typedef struct {
                                          * otherwise 0.*/
     uint32_t mpi_gpu_features;  /* OSHMPI_MPI_GPU_FEATURES: Arbitrary combination with bit shift defined in
                                  * OSHMPI_mpi_gpu_feature_shift_t. none and all are two special values. */
-#ifndef OSHMPI_ENABLE_FAST
+#ifndef OSHMPI_DISABLE_DEBUG
     OSHMPI_dbg_mode_t amo_dbg_mode;
     OSHMPI_dbg_mode_t rma_dbg_mode;
 #endif

--- a/src/include/oshmpi_impl.h
+++ b/src/include/oshmpi_impl.h
@@ -285,7 +285,8 @@ extern OSHMPI_env_t OSHMPI_env;
 #ifdef OSHMPI_ENABLE_THREAD_MULTIPLE
 #define OSHMPI_THREAD_INIT_CS(cs_ptr)  do {                   \
     if (OSHMPI_global.thread_level == SHMEM_THREAD_MULTIPLE) {\
-        int __err = OSHMPIU_thread_cs_init(cs_ptr);           \
+        int __err OSHMPI_ATTRIBUTE((unused));                 \
+        __err = OSHMPIU_thread_cs_init(cs_ptr);               \
         OSHMPI_ASSERT(!__err);                                \
     }                                                         \
 } while (0)
@@ -293,14 +294,15 @@ extern OSHMPI_env_t OSHMPI_env;
 #define OSHMPI_THREAD_DESTROY_CS(cs_ptr)  do {                 \
     if (OSHMPI_global.thread_level == SHMEM_THREAD_MULTIPLE && \
             OSHMPIU_THREAD_CS_IS_INITIALIZED(cs_ptr)) {        \
-        int __err = OSHMPIU_thread_cs_destroy(cs_ptr);         \
+        int __err OSHMPI_ATTRIBUTE((unused));                  \
+        __err = OSHMPIU_thread_cs_destroy(cs_ptr);             \
         OSHMPI_ASSERT(!__err);                                 \
     }                                                          \
 } while (0)
 
 #define OSHMPI_THREAD_ENTER_CS(cs_ptr)  do {                          \
     if (OSHMPI_global.thread_level == SHMEM_THREAD_MULTIPLE) {        \
-        int __err;                                                    \
+        int __err OSHMPI_ATTRIBUTE((unused));                         \
         __err = OSHMPIU_THREAD_CS_ENTER(cs_ptr);                      \
         OSHMPI_ASSERT(!__err);                                        \
     }                                                                 \
@@ -308,7 +310,7 @@ extern OSHMPI_env_t OSHMPI_env;
 
 #define OSHMPI_THREAD_EXIT_CS(cs_ptr)  do {                     \
     if (OSHMPI_global.thread_level == SHMEM_THREAD_MULTIPLE) {  \
-        int __err = 0;                                          \
+        int __err OSHMPI_ATTRIBUTE((unused));                   \
         __err = OSHMPIU_THREAD_CS_EXIT(cs_ptr);                 \
         OSHMPI_ASSERT(!__err);                                  \
     }                                                           \

--- a/src/internal/setup_impl.c
+++ b/src/internal/setup_impl.c
@@ -383,7 +383,7 @@ static void getstr_env_amo_ops(uint32_t val, char *buf, size_t maxlen)
         strncpy(buf, "none", maxlen);
 }
 
-#ifndef OSHMPI_ENABLE_FAST
+#ifndef OSHMPI_DISABLE_DEBUG
 static void set_env_dbg_mode(const char *str, OSHMPI_dbg_mode_t * dbg_mode)
 {
     if (!strncmp(str, "am", strlen("am"))) {
@@ -566,15 +566,15 @@ static void print_env(void)
                       "    OSHMPI_AMO_OPS               %s\n"
                       "    OSHMPI_ENABLE_ASYNC_THREAD   %d\n"
                       "    OSHMPI_MPI_GPU_FEATURES      %s\n"
-#ifndef OSHMPI_ENABLE_FAST
-                      "    (Invalid options if OSHMPI is built with --enable-fast)\n"
+#ifndef OSHMPI_DISABLE_DEBUG
+                      "    (Invalid options if OSHMPI is built with --enable-fast=ndebug)\n"
                       "    OSHMPI_AMO_DBG_MODE          %s\n"
                       "    OSHMPI_RMA_DBG_MODE          %s\n"
 #endif
                       ,OSHMPI_env.verbose, amo_ops_str,
                       OSHMPI_env.enable_async_thread,
                       mpi_gpu_features_str
-#ifndef OSHMPI_ENABLE_FAST
+#ifndef OSHMPI_DISABLE_DEBUG
                       ,getstr_env_dbg_mode(OSHMPI_env.amo_dbg_mode)
                       ,getstr_env_dbg_mode(OSHMPI_env.rma_dbg_mode)
 #endif
@@ -643,7 +643,7 @@ static void initialize_env(void)
     else
         set_env_mpi_gpu_features("all", &OSHMPI_env.mpi_gpu_features);  /* default */
 
-#ifndef OSHMPI_ENABLE_FAST
+#ifndef OSHMPI_DISABLE_DEBUG
     OSHMPI_env.amo_dbg_mode = OSHMPI_DBG_AUTO;
     val = getenv("OSHMPI_AMO_DBG_MODE");
     if (val && strlen(val))

--- a/src/internal/space_impl.c
+++ b/src/internal/space_impl.c
@@ -28,6 +28,7 @@ static void space_ictx_destroy(OSHMPI_ictx_t * ictx)
     ictx->win = MPI_WIN_NULL;
 }
 
+#ifndef OSHMPI_DISABLE_DEBUG
 static const char *space_memkind_str(shmemx_memkind_t memkind)
 {
     switch (memkind) {
@@ -40,6 +41,7 @@ static const char *space_memkind_str(shmemx_memkind_t memkind)
             break;
     }
 }
+#endif
 
 #ifdef OSHMPI_ENABLE_CUDA
 static void *space_cuda_malloc(MPI_Aint size)


### PR DESCRIPTION
Disable rma/amo mode debug when macro OSHMPI_DISABLE_DEBUG is set
by --enable-fast=ndebug