### PR TITLE
test: Extend ZE testing support

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -34,7 +34,9 @@ check_PROGRAMS += space_cuda               \
                   space_int_amo_cuda
 endif
 if OSHMPI_ENABLE_ZE_TEST
-check_PROGRAMS += space_ze
+check_PROGRAMS += space_ze                 \
+                  space_int_put_ze         \
+                  space_ctx_int_put_ze
 endif
 
 TESTS = $(check_PROGRAMS)
@@ -80,6 +82,12 @@ endif
 if OSHMPI_ENABLE_ZE_TEST
 space_ze_SOURCES = space.c
 space_ze_CPPFLAGS  = -DUSE_ZE $(AM_CPPFLAGS)
+
+space_int_put_ze_SOURCES = space_int_put.c
+space_int_put_ze_CPPFLAGS  = -DUSE_ZE $(AM_CPPFLAGS)
+
+space_ctx_int_put_ze_SOURCES = space_ctx_int_put.c
+space_ctx_int_put_ze_CPPFLAGS  = -DUSE_ZE $(AM_CPPFLAGS)
 endif
 
 .PHONY: checkprogs

--- a/tests/gpu_common.h
+++ b/tests/gpu_common.h
@@ -55,6 +55,8 @@ static int check_data(int size, int iter, int *dst)
 #include <level_zero/ze_api.h>
 #include <assert.h>
 
+ze_command_list_handle_t command_list;
+
 static void init_device(int mype, void **device_handle)
 {
     uint32_t driver_count = 0;
@@ -115,9 +117,68 @@ static void init_device(int mype, void **device_handle)
     assert(ret == ZE_RESULT_SUCCESS);
 
     *device_handle = ze_device_handles[mype % ze_device_count];
-
     free(ze_device_handles);
     free(all_drivers);
+
+    /* Create synchronous command list */
+    ze_command_queue_desc_t descriptor;
+    descriptor.stype = ZE_STRUCTURE_TYPE_COMMAND_QUEUE_DESC;
+    descriptor.pNext = NULL;
+    descriptor.flags = 0;
+    descriptor.index = 0;
+    descriptor.mode = ZE_COMMAND_QUEUE_MODE_SYNCHRONOUS;
+    descriptor.priority = ZE_COMMAND_QUEUE_PRIORITY_NORMAL;
+
+    uint32_t numQueueGroups = 0;
+    ret = zeDeviceGetCommandQueueGroupProperties(*device_handle, &numQueueGroups, NULL);
+    assert(ret == ZE_RESULT_SUCCESS && numQueueGroups > 0);
+    ze_command_queue_group_properties_t *queueProperties =
+        malloc(sizeof(ze_command_queue_group_properties_t) * numQueueGroups);
+    ret =
+        zeDeviceGetCommandQueueGroupProperties(*device_handle, &numQueueGroups,
+                                               queueProperties);
+    assert(ret == ZE_RESULT_SUCCESS);
+    descriptor.ordinal = -1;
+    for (int i = 0; i < numQueueGroups; i++) {
+        if (queueProperties[i].flags & ZE_COMMAND_QUEUE_GROUP_PROPERTY_FLAG_COMPUTE) {
+            descriptor.ordinal = i;
+            break;
+        }
+    }
+    assert(descriptor.ordinal != -1);
+
+    ret = zeCommandListCreateImmediate(ze_context, *device_handle, &descriptor, &command_list);
+    assert(ret == ZE_RESULT_SUCCESS);
+}
+
+static void reset_data(int mype, int size, int iter, int *src, int *dst)
+{
+    int *tmpbuf = malloc(size * iter * sizeof(int));
+
+    for (int i = 0; i < size * iter; i++)
+        tmpbuf[i] = mype + i;
+    zeCommandListAppendMemoryCopy(command_list, src, tmpbuf, size * iter * sizeof(int), NULL, 0, NULL);
+    char zero = 0;
+    zeCommandListAppendMemoryFill(command_list, dst, &zero, sizeof(char), size * iter * sizeof(int), NULL, 0, NULL);
+}
+
+static int check_data(int size, int iter, int *dst)
+{
+    int errs = 0;
+    int *tmpbuf = malloc(size * iter * sizeof(int));
+
+    zeCommandListAppendMemoryCopy(command_list, tmpbuf, dst, size * iter * sizeof(int), NULL, 0, NULL);
+    for (int i = 0; i < size * iter; i++) {
+        if (tmpbuf[i] != i) {
+            fprintf(stderr, "Excepted %d at dst[%d], but %d\n", i, i, tmpbuf[i]);
+            fflush(stderr);
+            errs++;
+        }
+    }
+
+    free(tmpbuf);
+
+    return errs;
 }
 #else
 static void init_device(int mype, void **device_handle)

--- a/tests/space_ctx_int_put.c
+++ b/tests/space_ctx_int_put.c
@@ -12,60 +12,10 @@
 
 #define SIZE 10
 #define ITER 10
-int mype, errs = 0;
-
-#ifdef USE_CUDA
-#include <cuda_runtime_api.h>
-
-static void reset_data(int *src, int *dst)
-{
-    int tmpbuf[SIZE * ITER];
-    int i;
-
-    for (i = 0; i < SIZE * ITER; i++)
-        tmpbuf[i] = mype + i;
-    cudaMemcpy(src, tmpbuf, SIZE * ITER * sizeof(int), cudaMemcpyHostToDevice);
-    cudaMemset(dst, 0, SIZE * ITER * sizeof(int));
-}
-
-static void check_data(int *dst)
-{
-    int tmpbuf[SIZE * ITER], i;
-    cudaMemcpy(tmpbuf, dst, SIZE * ITER * sizeof(int), cudaMemcpyDeviceToHost);
-    for (i = 0; i < SIZE * ITER; i++) {
-        if (tmpbuf[i] != i) {
-            fprintf(stderr, "Excepted %d at dst[%d], but %d\n", i, i, tmpbuf[i]);
-            fflush(stderr);
-            errs++;
-        }
-    }
-}
-#else
-static void reset_data(int *src, int *dst)
-{
-    int i;
-    for (i = 0; i < SIZE * ITER; i++) {
-        src[i] = mype + i;
-        dst[i] = 0;
-    }
-}
-
-static void check_data(int *dst)
-{
-    int i;
-    for (i = 0; i < SIZE * ITER; i++) {
-        if (dst[i] != i) {
-            fprintf(stderr, "Excepted %d at dst[%d], but %d\n", i, i, dst[i]);
-            fflush(stderr);
-            errs++;
-        }
-    }
-}
-#endif
-
 
 int main(int argc, char *argv[])
 {
+    int mype, errs = 0;
     int x;
 
     shmem_init();
@@ -93,7 +43,7 @@ int main(int argc, char *argv[])
     shmem_ctx_t space_ctx;
     shmemx_space_create_ctx(space, 0, &space_ctx);
 
-    reset_data(src, dst);
+    reset_data(mype, SIZE, ITER, src, dst);
     shmem_barrier_all();
 
     for (x = 0; x < ITER; x++) {
@@ -107,7 +57,7 @@ int main(int argc, char *argv[])
     shmem_barrier_all();
 
     if (mype == 1)
-        check_data(dst);
+        errs += check_data(SIZE, ITER, dst);
 
     shmem_free(dst);
     shmem_free(src);

--- a/tests/space_int_amo.c
+++ b/tests/space_int_amo.c
@@ -17,12 +17,12 @@ int mype, errs = 0;
 #ifdef USE_CUDA
 #include <cuda_runtime_api.h>
 
-static void reset_data(int *dst)
+static void reset_amo_data(int *dst)
 {
     cudaMemset(dst, 0, sizeof(int));
 }
 
-static void check_data(int *dst)
+static void check_amo_data(int *dst)
 {
     int tmpbuf;
     cudaMemcpy(&tmpbuf, dst, sizeof(int), cudaMemcpyDeviceToHost);
@@ -33,12 +33,12 @@ static void check_data(int *dst)
     }
 }
 #else
-static void reset_data(int *dst)
+static void reset_amo_data(int *dst)
 {
     dst[0] = 0;
 }
 
-static void check_data(int *dst)
+static void check_amo_data(int *dst)
 {
     if (dst[0] != ITER) {
         fprintf(stderr, "Excepted dst %d, but %d\n", ITER, dst[0]);
@@ -73,7 +73,7 @@ int main(int argc, char *argv[])
 
     int *dst = shmemx_space_malloc(space, sizeof(int));
 
-    reset_data(dst);
+    reset_amo_data(dst);
     shmem_barrier_all();
 
     for (x = 0; x < ITER; x++) {
@@ -90,7 +90,7 @@ int main(int argc, char *argv[])
     shmem_barrier_all();
 
     if (mype == 1)
-        check_data(dst);
+        check_amo_data(dst);
 
     shmem_free(dst);
     shmemx_space_detach(space);


### PR DESCRIPTION
Add utilities to initialize and copy ZE device memory. Enable ZE versions of space_int_put and space_ctx_int_put.