### PR TITLE
mpit: optionally disable MPI_T usage in OSHMPI

### DIFF
--- a/src/include/oshmpi_impl.h
+++ b/src/include/oshmpi_impl.h
@@ -279,6 +279,9 @@ typedef struct {
                                          * Invalid when OSHMPI_DISABLE_AM_ASYNC_THREAD is set.
                                          * Default value is 1 if either AMO or RMA is AM based;
                                          * otherwise 0.*/
+    unsigned int enable_mpit;   /* OSHMPI_ENABLE_MPI_T: Control mpi_t utilization at shmem_init.
+                                 * Value: 0 or 1. Default is 1, enables MPI_T setting.
+                                 * Set OSHMPI_ENABLE_MPI_T=0 to disable. */
     uint32_t mpi_gpu_features;  /* OSHMPI_MPI_GPU_FEATURES: Arbitrary combination with bit shift defined in
                                  * OSHMPI_mpi_gpu_feature_shift_t. none and all are two special values. */
 #ifndef OSHMPI_DISABLE_DEBUG

--- a/src/internal/setup_impl.c
+++ b/src/internal/setup_impl.c
@@ -576,6 +576,7 @@ static void print_env(void)
                       "    OSHMPI_AMO_OPS               %s\n"
                       "    OSHMPI_ENABLE_ASYNC_THREAD   %d\n"
                       "    OSHMPI_MPI_GPU_FEATURES      %s\n"
+                      "    OSHMPI_ENABLE_MPI_T          %d\n"
 #ifndef OSHMPI_DISABLE_DEBUG
                       "    (Invalid options if OSHMPI is built with --enable-fast=ndebug)\n"
                       "    OSHMPI_AMO_DBG_MODE          %s\n"
@@ -583,7 +584,8 @@ static void print_env(void)
 #endif
                       ,OSHMPI_env.verbose, amo_ops_str,
                       OSHMPI_env.enable_async_thread,
-                      mpi_gpu_features_str
+                      mpi_gpu_features_str,
+                      OSHMPI_env.enable_mpit
 #ifndef OSHMPI_DISABLE_DEBUG
                       ,getstr_env_dbg_mode(OSHMPI_env.amo_dbg_mode)
                       ,getstr_env_dbg_mode(OSHMPI_env.rma_dbg_mode)
@@ -682,6 +684,11 @@ static void initialize_env(void)
     if (OSHMPI_env.enable_async_thread != 0)
         OSHMPI_env.enable_async_thread = 1;
 #endif
+
+    OSHMPI_env.enable_mpit = 1;
+    val = getenv("OSHMPI_ENABLE_MPI_T");
+    if (val && strlen(val) && atoi(val) == 0)
+        OSHMPI_env.enable_mpit = 0;
 }
 
 static void set_mpit_cvar(const char *cvar_name, const void *val)
@@ -714,6 +721,9 @@ static void set_mpit_cvar(const char *cvar_name, const void *val)
 
 static void initialize_mpit(void)
 {
+    if (!OSHMPI_env.enable_mpit)
+        return;
+
     int val = 1;
     set_mpit_cvar("MPIR_CVAR_CH4_RMA_ENABLE_DYNAMIC_AM_PROGRESS", &val);
 }

--- a/src/internal/setup_impl.c
+++ b/src/internal/setup_impl.c
@@ -705,7 +705,7 @@ static void set_mpit_cvar(const char *cvar_name, const void *val)
 
     /* TODO: Add other data types when needed. */
     int val_read = 0;
-    OSHMPI_CALLMPI(PMPI_T_cvar_write(handle, val));
+    OSHMPI_CALLMPI(MPI_T_cvar_write(handle, val));
     OSHMPI_CALLMPI(MPI_T_cvar_read(handle, &val_read));
     OSHMPI_DBGMSG("MPI_T setup: %s = %d\n", cvar_name, val_read);
 


### PR DESCRIPTION
Add an environment variable to optionally disable MPI_T usage in OSHMPI.

Reason to add:
#105 reports a failure from FujitsuMPI occurred when calling `MPI_T_cvar_write` at OSHMPI init. It looks like FujitsuMPI does not return a proper error at the call to `MPI_T_cvar_get_index`. `MPI_T_ERR_INVALID_NAME` is expected when an MPI implementation specific CVAR  does not exist. 

This PR provides a workaround from OSHMPI. More checks need to be done with FujitsuMPI