### PR TITLE
AMO: setup MPI info hints to enable network atomics in MPI

### DIFF
--- a/src/internal/setup_impl.c
+++ b/src/internal/setup_impl.c
@@ -103,6 +103,10 @@ void OSHMPI_set_mpi_info_args(MPI_Info info)
         OSHMPI_global.amo_direct = 1;
     } else      /* MPI default */
         OSHMPI_CALLMPI(MPI_Info_set(info, "accumulate_ops", "same_op_no_op"));
+
+    /* disable_shm_accumulate.
+     * MPICH specific hint. Disable shm atomics otherwise no remote atomics can be offloaded to network */
+    OSHMPI_CALLMPI(MPI_Info_set(info, "disable_shm_accumulate", "true"));
 }
 
 #ifdef OSHMPI_ENABLE_DYNAMIC_WIN

--- a/src/internal/setup_impl.c
+++ b/src/internal/setup_impl.c
@@ -107,6 +107,11 @@ void OSHMPI_set_mpi_info_args(MPI_Info info)
     /* disable_shm_accumulate.
      * MPICH specific hint. Disable shm atomics otherwise no remote atomics can be offloaded to network */
     OSHMPI_CALLMPI(MPI_Info_set(info, "disable_shm_accumulate", "true"));
+
+    /* accumulate_ordering.
+     * MPI standard default ordering is rar,war,raw,waw, which may disable network atomics.
+     * OpenSHMEM does not guarantee ordering of AMO without explicit fence. Thus, we relax it. */
+    OSHMPI_CALLMPI(MPI_Info_set(info, "accumulate_ordering", "none"));
 }
 
 #ifdef OSHMPI_ENABLE_DYNAMIC_WIN


### PR DESCRIPTION
With `which_accumulate_ops`, we can legally use MPI accumulates for AMO. However, to enable use of network atomics in MPI layer as much as possible, we need two more hints:
- `disable_shm_accumulate`: explicitly disable CPU-based accumulates (using CPU-based atomics). MPICH specific hint.
- `accumulate_ordering=none`: OpenSHMEM AMO does not guarantee ordering between AMOs without fence. Thus, we should relax it.
    - Some network (ofi/gni, ofi/verbs) does not support ordered RMA/atomics, relaxing it allows MPI to utilize network atomics

