### PR TITLE
Add whitespace checker

### DIFF
--- a/maint/hooks/whitespace_checker
+++ b/maint/hooks/whitespace_checker
@@ -1,0 +1,93 @@
+#! /usr/bin/env bash
+##
+## Copyright (C) by Argonne National Laboratory
+##     See COPYRIGHT in top-level directory
+##
+
+# An example hook script to verify what is about to be committed.
+# Called by "git commit" with no arguments.  The hook should
+# exit with non-zero status after issuing an appropriate message if
+# it wants to stop the commit.
+#
+# To enable this hook, rename this file to "pre-commit".
+
+if git rev-parse --verify HEAD >/dev/null 2>&1
+then
+    against=HEAD
+else
+    # Initial commit: diff against an empty tree object
+    against=4b825dc642cb6eb9a060e54bf8d69288fbee4904
+fi
+
+# If you want to allow non-ASCII filenames set this variable to true.
+allownonascii=$(git config --bool hooks.allownonascii)
+
+# Redirect output to stderr.
+exec 1>&2
+
+# Cross platform projects tend to avoid non-ASCII filenames; prevent
+# them from being added to the repository. We exploit the fact that the
+# printable range starts at the space character and ends with tilde.
+if [ "$allownonascii" != "true" ] &&
+    # Note that the use of brackets around a tr range is ok here, (it's
+    # even required, for portability to Solaris 10's /usr/bin/tr), since
+    # the square bracket bytes happen to fall in the designated range.
+    test $(git diff --cached --name-only --diff-filter=A -z $against |
+        LC_ALL=C tr -d '[ -~]\0' | wc -c) != 0
+then
+    cat <<\EOF
+Error: Attempt to add a non-ASCII file name.
+
+This can cause problems if you want to work with people on other platforms.
+
+To be portable it is advisable to rename the file.
+
+If you know what you are doing you can disable this check using:
+
+  git config hooks.allownonascii true
+EOF
+    exit 1
+fi
+
+MIRROR=/tmp/${USER}/oshmpi-whitespace-$$
+TMP_FILENAME=/tmp/${USER}/oshmpi-tmp-$$
+
+# Checkout a copy of the current index into MIRROR
+git checkout-index --prefix=$MIRROR/ -af
+
+# Remove files from MIRROR which are no longer present in the index
+git diff-index --cached --name-only --diff-filter=D -z HEAD | \
+    (cd $MIRROR && xargs -0 rm -f --)
+
+# This will check the previous commit again when not amending a commit, but that
+# should be ok if the patches are correct.
+filestring=`git diff --cached --name-only --diff-filter=ACM HEAD~1`
+
+# Everything else happens in the temporary build tree
+pushd $MIRROR > /dev/null
+
+ret=0
+
+# This won't work if we ever have a file with a space in the name
+for file in $filestring
+do
+    if [[ ($file == *.c || $file == *.h || $file == *.c.in || $file == *.h.in) ]]; then
+        cp ${file} ${TMP_FILENAME}
+        maint/code-cleanup.sh ${file}
+        git --no-pager diff ${file} ${TMP_FILENAME}
+        if [ $? != 0 ] ; then
+            ret=1
+        fi
+    fi
+done
+
+rm -rf ${MIRROR} ${TMP_FILENAME}
+
+if [ $ret != 0 ] ; then
+    RED='\033[0;31m'
+    NC='\033[0m' # No Color
+    echo -e "${RED}== CODE CLEANUP SCRIPT FAILED ==${NC}"
+    exit $ret
+fi
+
+popd > /dev/null


### PR DESCRIPTION
Add `maint/hooks/whitespace_checker` to be used as pre-commit hooks and used for CI whitespace testing.

Setting up tests `whitespace` and `warnings`. Both should automatically as well as manually triggered via PR comments.

Fixes #113