### PR TITLE
warnings: clean up for warnings test

### DIFF
--- a/src/include/oshmpi_util.h
+++ b/src/include/oshmpi_util.h
@@ -162,7 +162,8 @@ OSHMPI_STATIC_INLINE_PREFIX uint64_t OSHMPIU_str_to_size(char *s)
 
     /* ceil is required to match the specification example
      * "3.1M is equivalent to the integer value 3250586" */
-    return (uint64_t) ceil(val);
+    uint64_t ret_val = ceil(val);
+    return ret_val;
 }
 
 /* ======================================================================

--- a/src/internal/util/dlmalloc.c
+++ b/src/internal/util/dlmalloc.c
@@ -582,8 +582,6 @@ MAX_RELEASE_CHECK_RATE   default: 4095 unless not HAVE_MMAP
 #include <sys/types.h>  /* For size_t */
 #endif /* LACKS_SYS_TYPES_H */
 
-#include "dlmalloc.h"
-
 /* The maximum possible size_t value has all bits set */
 #define MAX_SIZE_T           (~(size_t)0)
 

--- a/src/internal/util/dlmalloc.c
+++ b/src/internal/util/dlmalloc.c
@@ -1417,6 +1417,14 @@ extern "C" {
 */
     DLMALLOC_EXPORT int mspace_mallopt(int, int);
 
+/*
+  Additional exported functions.
+*/
+    DLMALLOC_EXPORT void *mspace_realloc_in_place(mspace msp, void *mem, size_t newsize);
+    DLMALLOC_EXPORT size_t mspace_bulk_free(mspace msp, void **, size_t n_elements);
+    DLMALLOC_EXPORT size_t mspace_footprint_limit(mspace msp);
+    DLMALLOC_EXPORT size_t mspace_set_footprint_limit(mspace msp, size_t bytes);
+
 #endif                          /* MSPACES */
 
 #ifdef __cplusplus


### PR DESCRIPTION
* Both gcc and clang warns on `(uint64_t) ceil(val)` -- `-Wbad-function-cast`.
* double `typedef void *mspace;` due to inclusion of `dlmalloc.h` in `dlmalloc.c`
